### PR TITLE
Add Tauri project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore build artifacts
+**/bin/
+**/obj/
+# Node and Rust
+node_modules/
+**/target/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Psych Report Table Maker
+
+This repository originally contained a VB.NET Windows Forms application that relies on Windows-specific technologies. To make the project cross-platform and macOS compatible, a new Tauri + Rust implementation is being introduced.
+
+## Structure
+
+- `Psych Report Table Maker/` – Legacy VB.NET application.
+- `tauri-app/` – New cross-platform Tauri project written in Rust.
+
+## Building the Legacy Application (Windows)
+
+1. Open `Psych Report Table Maker.sln` in Visual Studio 2010 or later.
+2. Restore NuGet packages (SQL Server CE, OpenXML, MathNet, etc.).
+3. Build the solution to produce a Windows executable.
+
+## New Tauri + Rust Project
+
+The `tauri-app` directory contains a skeleton Tauri project intended to replace the VB.NET application. It uses SQLite for data storage and will generate Word documents via the `docx-rs` crate.
+
+### Prerequisites
+
+- [Rust](https://rustup.rs/) with the stable toolchain.
+- [Node.js](https://nodejs.org/) (for the Tauri frontend build).
+
+### Build Steps
+
+```bash
+cd tauri-app
+npm install       # installs frontend dependencies
+npm run tauri dev # runs the Tauri application in development mode
+```
+
+To build a production bundle for macOS:
+
+```bash
+npm run tauri build -- --target aarch64-apple-darwin
+```
+
+### Porting Status
+
+Only a minimal Rust backend and SQLite setup are included. The original VB.NET logic and UI must still be translated into Rust commands and a web-based UI.

--- a/tauri-app/frontend/index.html
+++ b/tauri-app/frontend/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Psych Report Table Maker</title>
+</head>
+<body>
+  <h1>Psych Report Table Maker</h1>
+  <div id="app"></div>
+  <script>
+    window.addEventListener('DOMContentLoaded', () => {
+      document.getElementById('app').innerText = 'Tauri app placeholder';
+    });
+  </script>
+</body>
+</html>

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "psych-report-table-maker",
+  "version": "0.1.0",
+  "scripts": {
+    "tauri": "tauri",
+    "tauri dev": "tauri dev",
+    "tauri build": "tauri build"
+  },
+  "devDependencies": {
+    "@tauri-apps/cli": "^1.0.0"
+  }
+}

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tauri_app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "1", features = ["api-all"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+rusqlite = "0.30"
+docx-rs = "0.5"

--- a/tauri-app/src-tauri/src/main.rs
+++ b/tauri-app/src-tauri/src/main.rs
@@ -1,0 +1,32 @@
+use tauri::Manager;
+use rusqlite::{Connection, Result};
+
+#[tauri::command]
+fn generate_report() -> Result<String> {
+    // TODO: Implement report generation using docx-rs
+    Ok("Report generated".into())
+}
+
+fn init_db() -> Result<Connection> {
+    let conn = Connection::open("table_maker.db")?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS people (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL
+        )",
+        [],
+    )?;
+    Ok(conn)
+}
+
+fn main() {
+    tauri::Builder::default()
+        .setup(|app| {
+            // Initialize SQLite database on startup
+            let _conn = init_db().expect("failed to init db");
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![generate_report])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,0 +1,18 @@
+{
+  "build": {
+    "beforeBuildCommand": "",
+    "beforeDevCommand": "",
+    "devPath": "../frontend",
+    "distDir": "../frontend"
+  },
+  "package": {
+    "productName": "PsychReportTableMaker",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "bundle": {
+      "identifier": "com.example.psychreporttablemaker",
+      "icon": ["icons/32x32.png", "icons/128x128.png"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add new README with build and porting instructions
- create Tauri skeleton in `tauri-app/` with Rust backend and HTML frontend
- include a simple SQLite setup and placeholder report command
- add `.gitignore`

## Testing
- `cargo check` *(fails: failed to download crates)*