### PR TITLE
Add person command for Tauri prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore build artifacts
+**/bin/
+**/obj/
+# Node and Rust
+node_modules/
+**/target/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Psych Report Table Maker
+
+This repository originally contained a VB.NET Windows Forms application that relies on Windows-specific technologies. To make the project cross-platform and macOS compatible, a new Tauri + Rust implementation is being introduced.
+
+## Structure
+
+- `Psych Report Table Maker/` – Legacy VB.NET application.
+- `tauri-app/` – New cross-platform Tauri project written in Rust.
+
+## Building the Legacy Application (Windows)
+
+1. Open `Psych Report Table Maker.sln` in Visual Studio 2010 or later.
+2. Restore NuGet packages (SQL Server CE, OpenXML, MathNet, etc.).
+3. Build the solution to produce a Windows executable.
+
+## New Tauri + Rust Project
+
+The `tauri-app` directory contains a skeleton Tauri project intended to replace the VB.NET application. It uses SQLite for data storage and will generate Word documents via the `docx-rs` crate.
+
+### Prerequisites
+
+- [Rust](https://rustup.rs/) with the stable toolchain.
+- [Node.js](https://nodejs.org/) (for the Tauri frontend build).
+
+### Build Steps
+
+```bash
+cd tauri-app
+npm install       # installs frontend dependencies
+npm run tauri dev # runs the Tauri application in development mode
+```
+
+To build a production bundle for macOS:
+
+```bash
+npm run tauri build -- --target aarch64-apple-darwin
+```
+
+### Porting Status
+
+The Rust backend currently supports adding people to an SQLite database via the
+`add_person` command. The frontend contains a simple HTML form that invokes this
+command. Document generation and the rest of the VB.NET functionality remain to
+be ported.

--- a/tauri-app/frontend/index.html
+++ b/tauri-app/frontend/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Psych Report Table Maker</title>
+</head>
+<body>
+  <h1>Psych Report Table Maker</h1>
+  <form id="person-form">
+    <label>First Name <input type="text" id="first" /></label><br/>
+    <label>Last Name <input type="text" id="last" required/></label><br/>
+    <button type="submit">Add Person</button>
+  </form>
+  <div id="status"></div>
+  <script>
+    const { invoke } = window.__TAURI__.tauri;
+    document.getElementById('person-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const first = document.getElementById('first').value;
+      const last = document.getElementById('last').value;
+      try {
+        await invoke('add_person', { person: { first_name: first, last_name: last } });
+        document.getElementById('status').innerText = 'Person added';
+      } catch (err) {
+        document.getElementById('status').innerText = 'Error adding person';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "psych-report-table-maker",
+  "version": "0.1.0",
+  "scripts": {
+    "tauri": "tauri",
+    "tauri dev": "tauri dev",
+    "tauri build": "tauri build"
+  },
+  "devDependencies": {
+    "@tauri-apps/cli": "^1.0.0"
+  }
+}

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tauri_app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "1", features = ["api-all"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+rusqlite = "0.30"
+docx-rs = "0.5"

--- a/tauri-app/src-tauri/src/main.rs
+++ b/tauri-app/src-tauri/src/main.rs
@@ -1,0 +1,62 @@
+use tauri::Manager;
+use rusqlite::{params, Connection, Result};
+use serde::Deserialize;
+
+#[tauri::command]
+fn generate_report() -> Result<String> {
+    // TODO: Implement report generation using docx-rs
+    Ok("Report generated".into())
+}
+
+#[derive(Deserialize)]
+struct NewPerson {
+    first_name: String,
+    last_name: String,
+    client_id: Option<String>,
+    birthdate: Option<String>, // ISO 8601 date string
+    sex: Option<i32>,
+}
+
+fn init_db() -> Result<Connection> {
+    let conn = Connection::open("table_maker.db")?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS people (
+            id INTEGER PRIMARY KEY,
+            first_name TEXT,
+            last_name TEXT NOT NULL,
+            client_id TEXT,
+            birthdate TEXT,
+            sex INTEGER
+        )",
+        [],
+    )?;
+    Ok(conn)
+}
+
+#[tauri::command]
+fn add_person(person: NewPerson) -> Result<()> {
+    let conn = init_db()?;
+    conn.execute(
+        "INSERT INTO people (first_name, last_name, client_id, birthdate, sex) VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            person.first_name,
+            person.last_name,
+            person.client_id,
+            person.birthdate,
+            person.sex
+        ],
+    )?;
+    Ok(())
+}
+
+fn main() {
+    tauri::Builder::default()
+        .setup(|app| {
+            // Initialize SQLite database on startup
+            let _conn = init_db().expect("failed to init db");
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![add_person, generate_report])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,0 +1,18 @@
+{
+  "build": {
+    "beforeBuildCommand": "",
+    "beforeDevCommand": "",
+    "devPath": "../frontend",
+    "distDir": "../frontend"
+  },
+  "package": {
+    "productName": "PsychReportTableMaker",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "bundle": {
+      "identifier": "com.example.psychreporttablemaker",
+      "icon": ["icons/32x32.png", "icons/128x128.png"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `add_person` Tauri command and SQLite schema
- wire up a simple HTML form to call the command
- document current porting status in README

## Testing
- `cargo check --manifest-path tauri-app/src-tauri/Cargo.toml --offline` *(fails: no matching package named `docx-rs`)*
- `npm install` *(fails: network unreachable)*